### PR TITLE
Improves work for #7

### DIFF
--- a/FastUnlockX13.xm
+++ b/FastUnlockX13.xm
@@ -26,7 +26,7 @@ extern BOOL settingsValueFor(NSString *prefKey);
     * pulling the notification center  down. When viewWillAppear: is called we can determine
     * if the presentation was manual since the controller will already be authenticated.
     */
-    self.fux_alreadyAuthenticated = self.authenticated;
+    self.fux_alreadyAuthenticated = (MSHookIvar<NSUInteger>([objc_getClass("SBLockStateAggregator") sharedInstance], "_lockState") == 0);
 }
 
 /*
@@ -105,16 +105,6 @@ extern BOOL settingsValueFor(NSString *prefKey);
         }
     }
 }
-
-- (void)setInScreenOffMode:(BOOL)screenOff {
-    %orig;
-
-    /*
-     * Reset fux_alreadyAuthenticated. If screen goes off we are not authenticated anymore.
-     */
-     self.fux_alreadyAuthenticated = !screenOff;
-}
-
 %end // CSCoverSheetViewController
 
 %end // FUX_13


### PR DESCRIPTION
This will get it to work after the first unlock after a respring. Unfortunately, there is a bug that if you are in the Notification Center when you lock your device, it won't autounlock.

The setInScreenOffMode method doesn't appear to be working on iOS 13 and therefore the cause for the issue of the device only autounlocking the first time after a respring.